### PR TITLE
Fix the conversion.

### DIFF
--- a/mixer/adapter/turbo/discovery/istio_discovery_client.go
+++ b/mixer/adapter/turbo/discovery/istio_discovery_client.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	// KBPS
-	KBPS = 1024 * 60
+	// KBPS conversion
+	KBPS = 1.024
 	// Default destination port
 	DEFAULT_DESTINATION_PORT = 8080
 )
@@ -77,6 +77,8 @@ func (client *IstioDiscoveryClient) Discover(accountValues []*proto.AccountValue
 }
 
 // Perform the discovery
+// The amount is in bytes. The duration is in ms.
+// We need KB/s - (amount / 1024) / (duration / 1000)
 func (client *IstioDiscoveryClient) doDiscover() ([]*proto.FlowDTO, error) {
 	var flows []*proto.FlowDTO
 	metrics := client.metricHandler.GetMetrics()

--- a/mixer/adapter/turbo/discovery/istio_discovery_client_test.go
+++ b/mixer/adapter/turbo/discovery/istio_discovery_client_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"math"
 	"testing"
 	"github.com/magiconair/properties/assert"
 	"fmt"
@@ -75,4 +76,15 @@ func TestIstioDiscoveryClient_Discover(t *testing.T) {
 	response, err := client.Discover(accountValues)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(response.FlowDTO), 1)
+}
+
+func TestAmount(t *testing.T) {
+	amount := 10000.
+	duration := 120.
+
+	kbps1 := (amount / 1024.) / (duration / 1000.)
+	kbps2 := (amount / duration) / (1024. / 1000.)
+	kbps3 := (amount / duration) / (KBPS)
+	assert.Equal(t, true, math.Abs(kbps1 - kbps2) < 0.0000000001)
+	assert.Equal(t, kbps2, kbps3)
 }

--- a/mixer/adapter/turbo/turbo.go
+++ b/mixer/adapter/turbo/turbo.go
@@ -136,7 +136,7 @@ func (h *handler) buildMetric(name string, value interface{}, builder *discovery
 		if !ok {
 			return h.bld.metricHandler.NewMetricBuilder()
 		}
-		builder = builder.WithDuration(int(duration.Nanoseconds() / 1000))
+		builder = builder.WithDuration(int(duration.Nanoseconds() / 1000000))
 	}
 	return builder
 }


### PR DESCRIPTION
1. The ns -> ms is ms = ns / 1000000, not ms = ns / 1000
2. We don't get bytes/minute, we are getting bytes/ms. So adjust accordingly.